### PR TITLE
Allow user to manually set the offset of the arrow

### DIFF
--- a/src/components/Floater/Arrow.js
+++ b/src/components/Floater/Arrow.js
@@ -43,8 +43,8 @@ export default class Arrow extends React.Component {
 
   render() {
     const { placement, setArrowRef, styles } = this.props;
-    const { arrow: { color, display, length, position, spread } } = styles;
-    const arrowStyles = { display, position };
+    const { arrow: { color, display, length, position, spread, left, top, right, bottom } } = styles;
+    const arrowStyles = { display, position, left, top, right, bottom };
 
     let points;
     let x = spread;

--- a/src/components/Floater/Arrow.js
+++ b/src/components/Floater/Arrow.js
@@ -44,7 +44,14 @@ export default class Arrow extends React.Component {
   render() {
     const { placement, setArrowRef, styles } = this.props;
     const { arrow: { color, display, length, position, spread, left, top, right, bottom } } = styles;
-    const arrowStyles = { display, position, left, top, right, bottom };
+    const arrowStyles = { display, position };
+    const parentStyleWithOffsets = {
+      ...this.parentStyle,
+      left: left || this.parentStyle.left,
+      top: top || this.parentStyle.top,
+      right: right || this.parentStyle.right,
+      bottom: bottom || this.parentStyle.bottom,
+    };
 
     let points;
     let x = spread;
@@ -75,7 +82,7 @@ export default class Arrow extends React.Component {
     return (
       <div
         className="__floater__arrow"
-        style={this.parentStyle}
+        style={parentStyleWithOffsets}
       >
         <span ref={setArrowRef} style={arrowStyles}>
           <svg


### PR DESCRIPTION
This is based on #37 where I discussed what my use case for this was.

The way this works is by adding an additional option for the arrow styles. So at the moment we have:

```
  arrow: {
    color: '#fff',
    display: 'inline-flex',
    length: 16,
    position: 'absolute',
    spread: 32,
  }
```

This PR will change this to be:

 ```
  arrow: {
    color: '#fff',
    display: 'inline-flex',
    length: 16,
    position: 'absolute',
    spread: 32,
    left: 0,
    top: 0,
    right: 0,
    bottom: 0,
  }
```

Below is the how it looks now.

<img width="316" alt="screen shot 2018-08-09 at 09 08 00" src="https://user-images.githubusercontent.com/3327152/43886723-94e8ee36-9bb4-11e8-9cd4-4e416367a476.png">

And now when I set `left` to `-100`.

<img width="325" alt="screen shot 2018-08-09 at 09 13 53" src="https://user-images.githubusercontent.com/3327152/43886733-990b4c02-9bb4-11e8-8eba-4317246d7ad3.png">
