### PR TITLE
Added the ability to provide an open delay for the floater

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ The distance between the Floater and its target in pixels.
 The switch between normal and controlled modes.  
 *Setting this prop will disabled the normal behavior.*
 
+**openDelay** {number} ▶︎ `0`  
+The amount of time (in seconds) that the floater should wait after a `mouseEnter` event before showing.
+Only valid for the event type `hover`.
+
 **placement** {string} ▶︎ `bottom`  
 The placement of the Floater. It will update the position if there's no space available.
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -67,6 +67,7 @@ export default class ReactFloater extends React.Component {
     isPositioned: PropTypes.bool,
     offset: PropTypes.number,
     open: PropTypes.bool,
+    openDelay: PropTypes.number,
     options: PropTypes.object,
     placement: PropTypes.oneOf([
       'top', 'top-start', 'top-end',
@@ -108,6 +109,7 @@ export default class ReactFloater extends React.Component {
     getPopper: noop,
     hideArrow: false,
     offset: 15,
+    openDelay: 0,
     placement: 'bottom',
     showCloseButton: false,
     styles: {},
@@ -364,7 +366,7 @@ export default class ReactFloater extends React.Component {
   };
 
   handleMouseEnter = () => {
-    const { event, open } = this.props;
+    const { event, open, openDelay } = this.props;
 
     if (is.boolean(open) || isMobile()) return;
 
@@ -381,7 +383,12 @@ export default class ReactFloater extends React.Component {
       });
 
       clearTimeout(this.eventDelayTimeout);
-      this.toggle();
+
+      this.openDelayTimeout = setTimeout(() => {
+        delete this.openDelayTimeout;
+
+        this.toggle();
+      }, openDelay * 1000);
     }
   };
 
@@ -401,6 +408,8 @@ export default class ReactFloater extends React.Component {
         ],
         debug: this.debug,
       });
+
+      clearTimeout(this.openDelayTimeout);
 
       if (!eventDelay) {
         this.toggle(STATUS.IDLE);


### PR DESCRIPTION
I required the ability to show a tooltip when the user hovered over a control for _n_ seconds.

This PR allows you to specify an `openDelay`, so that the floater will only show after the time specified.

I have also created an issue for this: #39