### PR TITLE
TS: changed types from dom node to react node

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -38,17 +38,17 @@ declare module "react-floater" {
     /**
      * An element to trigger the Floater.
      */
-    children?: Node,
+    children?: React.ReactNode,
     /**
      * A React component or function to as a custom UI for the Floater.
      * The prop closeFloater will be available in your component.
      */
-    component?: Node,
+    component?: React.ReactNode,
     /**
      * The Floater content. It can be anything that can be rendered.
      * This is the only required props, unless you pass a component.
      */
-    content: Node,
+    content: React.ReactNode,
     /**
      * Log some basic actions.
      */
@@ -77,7 +77,7 @@ declare module "react-floater" {
     /**
      * It can be anything that can be rendered.
      */
-    footer?: Node,
+    footer?: React.ReactNode,
     /**
      * Get the pooper.js instance
      */
@@ -123,7 +123,7 @@ declare module "react-floater" {
     /**
      * It can be anything that can be rendered.
      */
-    title?: Node,
+    title?: React.ReactNode,
     /**
      * Position the wrapper relative to the target.
      */
@@ -131,7 +131,7 @@ declare module "react-floater" {
   }
 
   export class Joyride extends React.Component<Props> {
-    constructor( props: Props );
+    constructor(props: Props);
 
     static defaultProps: Props;
   }


### PR DESCRIPTION
Had an issue using your library:
![screenshot 2018-10-15 20 57 17](https://user-images.githubusercontent.com/13867964/46973809-982b2f80-d0c2-11e8-9a53-ddfa207d8024.png)
Several props used Node as types which connects to lib.dom.d.ts. Fixed this by using `React.ReactNode` which pretty much accepts anything react can render.

