### PR TITLE
Body border radius

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+text eol=lf

--- a/src/components/Floater/Arrow.js
+++ b/src/components/Floater/Arrow.js
@@ -43,7 +43,7 @@ export default class FloaterArrow extends React.Component {
 
   render() {
     const { placement, setArrowRef, styles } = this.props;
-    const { arrow: { color, display, length, position, spread } } = styles;
+    const { arrow: { color, display, length, margin, position, spread } } = styles;
     const arrowStyles = { display, position };
 
     let points;
@@ -54,22 +54,30 @@ export default class FloaterArrow extends React.Component {
     if (placement.startsWith('top')) {
       points = `0,0 ${x / 2},${y} ${x},0`;
       arrowStyles.bottom = 0;
+      arrowStyles.marginLeft = margin;
+      arrowStyles.marginRight = margin;
     }
     else if (placement.startsWith('bottom')) {
       points = `${x},${y} ${x / 2},0 0,${y}`;
       arrowStyles.top = 0;
+      arrowStyles.marginLeft = margin;
+      arrowStyles.marginRight = margin;
     }
     else if (placement.startsWith('left')) {
       y = spread;
       x = length;
       points = `0,0 ${x},${y / 2} 0,${y}`;
       arrowStyles.right = 0;
+      arrowStyles.marginTop = margin;
+      arrowStyles.marginBottom = margin;
     }
     else if (placement.startsWith('right')) {
       y = spread;
       x = length;
       points = `${x},${y} ${x},0 0,${y / 2}`;
       arrowStyles.left = 0;
+      arrowStyles.marginTop = margin;
+      arrowStyles.marginBottom = margin;
     }
 
     return (

--- a/src/styles.js
+++ b/src/styles.js
@@ -96,7 +96,7 @@ export default function getStyles(styles) {
       color: '#fff',
       display: 'inline-flex',
       length: 16,
-      margin: 0,
+      margin: 8,
       position: 'absolute',
       spread: 32,
     },

--- a/src/styles.js
+++ b/src/styles.js
@@ -96,6 +96,7 @@ export default function getStyles(styles) {
       color: '#fff',
       display: 'inline-flex',
       length: 16,
+      margin: 0,
       position: 'absolute',
       spread: 32,
     },

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -68,7 +68,7 @@ exports[`ReactFloater with \`component\` as element should have rendered the com
           "color": "#fff",
           "display": "inline-flex",
           "length": 16,
-          "margin": 0,
+          "margin": 8,
           "position": "absolute",
           "spread": 32,
         },
@@ -183,8 +183,8 @@ exports[`ReactFloater with \`component\` as element should have rendered the com
         style={
           Object {
             "display": "inline-flex",
-            "marginLeft": 0,
-            "marginRight": 0,
+            "marginLeft": 8,
+            "marginRight": 8,
             "position": "absolute",
             "top": 0,
           }
@@ -271,7 +271,7 @@ exports[`ReactFloater with \`component\` as function should have rendered the co
           "color": "#fff",
           "display": "inline-flex",
           "length": 16,
-          "margin": 0,
+          "margin": 8,
           "position": "absolute",
           "spread": 32,
         },
@@ -386,8 +386,8 @@ exports[`ReactFloater with \`component\` as function should have rendered the co
         style={
           Object {
             "display": "inline-flex",
-            "marginLeft": 0,
-            "marginRight": 0,
+            "marginLeft": 8,
+            "marginRight": 8,
             "position": "absolute",
             "top": 0,
           }

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -68,6 +68,7 @@ exports[`ReactFloater with \`component\` as element should have rendered the com
           "color": "#fff",
           "display": "inline-flex",
           "length": 16,
+          "margin": 0,
           "position": "absolute",
           "spread": 32,
         },
@@ -182,6 +183,8 @@ exports[`ReactFloater with \`component\` as element should have rendered the com
         style={
           Object {
             "display": "inline-flex",
+            "marginLeft": 0,
+            "marginRight": 0,
             "position": "absolute",
             "top": 0,
           }
@@ -268,6 +271,7 @@ exports[`ReactFloater with \`component\` as function should have rendered the co
           "color": "#fff",
           "display": "inline-flex",
           "length": 16,
+          "margin": 0,
           "position": "absolute",
           "spread": 32,
         },
@@ -382,6 +386,8 @@ exports[`ReactFloater with \`component\` as function should have rendered the co
         style={
           Object {
             "display": "inline-flex",
+            "marginLeft": 0,
+            "marginRight": 0,
             "position": "absolute",
             "top": 0,
           }


### PR DESCRIPTION
Fix for issue when the arrow is clashing with the body border-radius.
There where two ways of fixing it - provide own modifier function for the arrow, or set margin for the arrow.
I've chosen to set margin of the arrow - because in arrow modifier in popper (https://github.com/FezVrasta/popper.js/blob/master/packages/popper/src/modifiers/arrow.js) `arrowElementSize` includes margins.