### PR TITLE
Fix arrow positioning on IE 11

### DIFF
--- a/src/components/Floater/Arrow.js
+++ b/src/components/Floater/Arrow.js
@@ -13,6 +13,7 @@ export default class FloaterArrow extends React.Component {
     const { length } = styles.arrow;
     const arrow = {
       position: 'absolute',
+      width: '100%',
     };
 
     /* istanbul ignore else */

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -176,6 +176,7 @@ exports[`ReactFloater with \`component\` as element should have rendered the com
           "position": "absolute",
           "right": 0,
           "top": 0,
+          "width": "100%",
         }
       }
     >
@@ -379,6 +380,7 @@ exports[`ReactFloater with \`component\` as function should have rendered the co
           "position": "absolute",
           "right": 0,
           "top": 0,
+          "width": "100%",
         }
       }
     >


### PR DESCRIPTION
Fix the left arrow being misplaced on IE 11. This closes https://github.com/gilbarbara/react-floater/issues/63